### PR TITLE
Validate should render nothing if valid

### DIFF
--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -28,6 +28,15 @@ test("util.quiet hides result", () => {
   expect(res).toEqual({ test: [1] });
 });
 
+test("util.validate hides result if valid", () => {
+  const vtl = `
+  $util.validate(true, "Error")
+  {}`;
+  const parser = new Parser(vtl);
+  const res = parser.resolve({});
+  expect(res).toEqual({});
+});
+
 test("resolve with additional util", () => {
   const mockRdsToJsonObject = jest.fn();
   const rdsResult = "rds result text";

--- a/src/tests/util.test.ts
+++ b/src/tests/util.test.ts
@@ -127,13 +127,14 @@ test("appendError does nothing", () => {
 });
 
 describe("validate", () => {
-  test("false throughs an error", () => {
+  test("false throws an error", () => {
     const testMessage = "errorMessage";
     expect(() => validate(false, testMessage)).toThrow(testMessage);
   });
 
-  test("true does nothing", () => {
-    validate(true, "errorMessage");
+  test("true returns a blank string", () => {
+    const result = validate(true, "errorMessage");
+    expect(result).toBe("");
   });
 });
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -64,6 +64,7 @@ export function validate(bool: Boolean, message?: string) {
   if (!bool) {
     throw new Error(message);
   }
+  return "";
 }
 
 export function isNull(input?: any) {


### PR DESCRIPTION
Hi,

I noticed an issue with `validate`. When I put `$util.validate(true, "Error")` in a template, it renders it as a literal string. I think it should render nothing instead, so I added a `return ""`. I also added a testcase to simulate the issue.