### PR TITLE
Add a return macro

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,14 @@ export default class Parser {
       utils: util,
     };
 
-    const res = render(this.template, params);
+    const macros = {
+      return(this: { stop(): void }, value: unknown | undefined) {
+        this.stop();
+        return value !== undefined ? JSON.stringify(value) : "null";
+      },
+    };
+
+    const res = render(this.template, params, macros);
 
     // Remove preceeding and trailing whitespace
     const resWithoutWhitespace = res

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -47,6 +47,24 @@ test("resolve with additional util", () => {
   expect(res).toEqual({ test: 10 });
 });
 
+test("#return can return an object early", () => {
+  const vtl = `
+  #return({"result": "A"})
+  {"result": "B"}`;
+  const parser = new Parser(vtl);
+  const res = parser.resolve({});
+  expect(res).toEqual({ result: "A" });
+});
+
+test("#return returns null if called without arguments", () => {
+  const vtl = `
+  #return()
+  {"result": "B"}`;
+  const parser = new Parser(vtl);
+  const res = parser.resolve({});
+  expect(res).toEqual(null);
+});
+
 describe("Typecasting works as expected", () => {
   test("Boolean false", () => {
     const vtl = "\nfalse "; // Note surrounding whitespace should be ignored


### PR DESCRIPTION
AppSync has a `#return` macro that returns a value early without evaluating the rest of the template. See also https://docs.aws.amazon.com/appsync/latest/devguide/resolver-util-reference.html#aws-appsync-directives 

We can define these kinds of custom macros by passing a third parameter to VelocityJS. 