### PR TITLE
Update number type to return number as string

### DIFF
--- a/src/tests/util-dynamodb.test.ts
+++ b/src/tests/util-dynamodb.test.ts
@@ -41,7 +41,7 @@ describe("string", () => {
 
 describe("number", () => {
   const i = 12345;
-  const expected = { N: 12345 };
+  const expected = { N: "12345" };
 
   test("toNumber", () => {
     const res = toNumber(i);
@@ -84,7 +84,7 @@ describe("list", () => {
   const expected = {
     L: [
       { S: "foo" },
-      { N: 123 },
+      { N: "123" },
       {
         M: {
           bar: { S: "baz" },
@@ -114,7 +114,7 @@ describe("map", () => {
   const expected = {
     M: {
       foo: { S: "bar" },
-      baz: { N: 1234 },
+      baz: { N: "1234" },
       beep: {
         L: [{ S: "boop" }],
       },

--- a/src/util-dynamodb.ts
+++ b/src/util-dynamodb.ts
@@ -11,7 +11,7 @@ export function toStringJson(str: string) {
 }
 
 export function toNumber(num: number) {
-  return { N: num };
+  return { N: num.toString() };
 }
 
 export function toNumberJson(num: number) {


### PR DESCRIPTION
AWS DynamoDB document states that the attribute number is a string and confirmed this is the case when checking the JSON of a DynamoDB property that has a number attribute. Link to the AWS Documentation - https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_PutItem.html. 

I have made the changes to reflect this but please let me know if any other changes needs to be made (first time contributing to an open source project)

