### PR TITLE
feat: support more vtl language like array.contains

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 // eslint-disable-next-line max-classes-per-file
 import { render } from "velocityjs";
+import { valueMapper } from "./value-mapper/mapper";
 import * as utilCore from "./util";
 import * as time from "./util-time";
 import * as dynamodb from "./util-dynamodb";
@@ -48,7 +49,7 @@ export default class Parser {
       },
     };
 
-    const res = render(this.template, params, macros);
+    const res = render(this.template, params, macros, { valueMapper });
 
     // Keep stash value
     this.internalStash = clonedContext.stash;

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -56,6 +56,15 @@ test("resolve with additional util", () => {
   expect(res).toEqual({ test: 10 });
 });
 
+test("valueMapper works correctly", () => {
+  const vtl = `
+  #set($array = [1,2,3])
+  { "test": $array.contains(1) }`;
+  const parser = new Parser(vtl);
+  const res = parser.resolve({});
+  expect(res).toEqual({ test: true });
+});
+
 test("#return can return an object early", () => {
   const vtl = `
   #return({"result": "A"})

--- a/src/value-mapper/array.ts
+++ b/src/value-mapper/array.ts
@@ -1,0 +1,66 @@
+import { toJSON } from "./to-json";
+
+export class JavaArray extends Array<any> {
+  private mapper: Function;
+
+  constructor(values: any, mapper: Function) {
+    let val = values;
+    if (!Array.isArray(values)) {
+      // splice sends a single object
+      val = [values];
+    }
+    if (val.length !== 1) {
+      super(...val);
+    } else {
+      super();
+      this.push(val[0]);
+    }
+    Object.setPrototypeOf(this, Object.create(JavaArray.prototype));
+    this.mapper = mapper;
+  }
+
+  add(value: any) {
+    this.push(this.mapper(value));
+    return value;
+  }
+
+  addAll(value: any) {
+    value.forEach((val: any) => this.push(this.mapper(val)));
+  }
+
+  clear() {
+    this.length = 0;
+  }
+
+  contains(value: any) {
+    const val = value && value.toJSON ? value.toJSON() : value;
+    return this.toJSON().indexOf(val) !== -1;
+  }
+
+  containsAll(value: Array<any> = []) {
+    return value.every((v) => this.contains(v));
+  }
+
+  isEmpty() {
+    return this.length === 0;
+  }
+
+  remove(value: any) {
+    const idx = this.indexOf(value);
+    if (idx === -1) return;
+    this.splice(idx, 1);
+  }
+
+  removeAll(value: any) {
+    const self = this;
+    value.forEach((val: any) => self.remove(val));
+  }
+
+  size() {
+    return this.length;
+  }
+
+  toJSON() {
+    return Array.from(this).map(toJSON);
+  }
+}

--- a/src/value-mapper/map.ts
+++ b/src/value-mapper/map.ts
@@ -1,0 +1,125 @@
+import { JavaArray } from "./array";
+import { toJSON } from "./to-json";
+
+export function createMapProxy(map: any) {
+  return new Proxy(map, {
+    get(obj, prop) {
+      if (map.map.has(prop)) {
+        return map.get(prop);
+      }
+      return map[prop];
+    },
+    set(obj, prop, val) {
+      if (typeof val !== "function") {
+        map.map.set(prop, val);
+      }
+      return true;
+    },
+  });
+}
+
+export class JavaMap {
+  private map: Map<string, any>;
+
+  private mapper: Function;
+
+  constructor(obj: any, mapper: Function) {
+    this.mapper = mapper;
+    this.map = new Map();
+    Object.entries(obj).forEach(([key, value]) => {
+      this.map.set(key, value);
+    });
+  }
+
+  clear() {
+    this.map.clear();
+  }
+
+  containsKey(key: any) {
+    return this.map.has(key);
+  }
+
+  containsValue(value: any) {
+    return Array.from(this.map.values()).indexOf(value) !== -1;
+  }
+
+  entrySet() {
+    const entries = Array.from(this.map.entries()).map(([key, value]) =>
+      createMapProxy(
+        new JavaMap(
+          {
+            key,
+            value,
+          },
+          this.mapper
+        )
+      )
+    );
+
+    return new JavaArray(entries, this.mapper);
+  }
+
+  equals(value: any) {
+    return Array.from(this.map.entries()).every(
+      ([key, v]) => value.get(key) === v
+    );
+  }
+
+  get(key: any) {
+    if (this.map.has(key.toString())) {
+      return this.map.get(key.toString());
+    }
+    return null;
+  }
+
+  isEmpty() {
+    return this.map.size === 0;
+  }
+
+  keySet() {
+    return new JavaArray(
+      Array.from(this.map.keys()).map(this.mapper as any),
+      this.mapper
+    );
+  }
+
+  put(key: any, value: any) {
+    const saveValue = this.mapper(value);
+    this.map.set(key, saveValue);
+    return saveValue;
+  }
+
+  putAll(map: object | JavaMap) {
+    const m = toJSON(map);
+    Object.entries(m).forEach(([key, value]) => {
+      this.put(key, value);
+    });
+  }
+
+  remove(key: any) {
+    if (!this.map.has(key)) {
+      return null;
+    }
+    const value = this.map.get(key);
+    this.map.delete(key);
+    return value;
+  }
+
+  size() {
+    return this.map.size;
+  }
+
+  values() {
+    return new JavaArray(Array.from(this.map.values()), this.mapper);
+  }
+
+  toJSON() {
+    return Array.from(this.map.entries()).reduce(
+      (sum, [key, value]) => ({
+        ...sum,
+        [key]: toJSON(value),
+      }),
+      {}
+    );
+  }
+}

--- a/src/value-mapper/mapper.ts
+++ b/src/value-mapper/mapper.ts
@@ -1,0 +1,38 @@
+import { JavaMap, createMapProxy } from "./map";
+import { JavaArray } from "./array";
+import { JavaString } from "./string";
+
+function isPlainObject(value: any) {
+  return Object.prototype.toString.call(value) === "[object Object]";
+}
+
+export function valueMapper(value: any): any {
+  if (value instanceof JavaMap) return value;
+  if (value instanceof JavaArray) return value;
+  if (Array.isArray(value)) {
+    return new JavaArray(
+      value.map((x) => valueMapper(x)),
+      valueMapper
+    );
+  }
+  if (isPlainObject(value)) {
+    return createMapProxy(
+      new JavaMap(
+        Object.entries(value).reduce((sum, [k, v]) => {
+          return {
+            ...sum,
+            [k]: valueMapper(v),
+          };
+        }, {}),
+        valueMapper
+      )
+    );
+  }
+
+  if (typeof value === "string" && !((value as any) instanceof JavaString)) {
+    return new JavaString(value);
+  }
+
+  // for now we don't handle number.
+  return value;
+}

--- a/src/value-mapper/string.ts
+++ b/src/value-mapper/string.ts
@@ -64,8 +64,8 @@ export class JavaString {
     // in the regex into the result. To remove the groups from the result we need the count of capturing groups in
     // the provided regex, the only way in JS seems to be via a match to an empty string
     const testRe = new RegExp(`${regexString.toString()}|`);
-    // @ts-ignore: Object is possibly 'null'.
-    const ngroups = "".match(testRe).length; // actually num of groups plus one, ie "" and the (empty) groups
+    const matches = "".match(testRe);
+    const ngroups = matches ? matches.length : 0; // actually num of groups plus one, ie "" and the (empty) groups
 
     const re = new RegExp(regexString.toString());
 

--- a/src/value-mapper/string.ts
+++ b/src/value-mapper/string.ts
@@ -1,0 +1,113 @@
+import { JavaArray } from "./array";
+
+export class JavaString {
+  value: string;
+
+  constructor(str: any) {
+    this.value = str;
+  }
+
+  concat(str: any) {
+    return new JavaString(this.value.concat(str.toString()));
+  }
+
+  contains(str: any) {
+    return this.value.indexOf(str.toString()) !== -1;
+  }
+
+  endsWith(suffix: any) {
+    return this.value.endsWith(suffix.toString());
+  }
+
+  equals(str: any) {
+    return this.value === str.toString();
+  }
+
+  indexOf(val: any, fromIndex = 0) {
+    return this.value.indexOf(val.toString(), fromIndex);
+  }
+
+  isEmpty() {
+    return this.value.length === 0;
+  }
+
+  lastIndexOf(val: any, fromIndex = Infinity) {
+    return this.value.lastIndexOf(val.toString(), fromIndex);
+  }
+
+  replace(find: any, replace: any) {
+    return this.replaceAll(find, replace);
+  }
+
+  replaceAll(find: any, replace: any) {
+    const rep = this.value.replace(new RegExp(find, "g"), replace);
+    return new JavaString(rep);
+  }
+
+  replaceFirst(find: any, replace: any) {
+    const rep = this.value.replace(new RegExp(find), replace);
+    return new JavaString(rep);
+  }
+
+  matches(regexString: any) {
+    const re = new RegExp(regexString.toString());
+
+    return this.value.match(re) !== null;
+  }
+
+  split(regexString: any, limit = undefined) {
+    // WARNING: this assumes Java and JavaScript regular expressions are identical, according to
+    // https://en.wikipedia.org/wiki/Comparison_of_regular_expression_engines#Language_features
+    // this should be the case except for look-behind which is not implemented in JavaScript
+
+    // java.util.String.split does not to include the separator in the result. JS does splice any capturing group
+    // in the regex into the result. To remove the groups from the result we need the count of capturing groups in
+    // the provided regex, the only way in JS seems to be via a match to an empty string
+    const testRe = new RegExp(`${regexString.toString()}|`);
+    // @ts-ignore: Object is possibly 'null'.
+    const ngroups = "".match(testRe).length; // actually num of groups plus one, ie "" and the (empty) groups
+
+    const re = new RegExp(regexString.toString());
+
+    const result = this.value
+      .split(re, limit)
+      .filter((v, ii) => !(ii % ngroups));
+    return new JavaArray(result, (e: any) => new JavaString(e.toString()));
+  }
+
+  startsWith(prefix: any, toffset = 0) {
+    return this.value.startsWith(prefix.toString(), toffset);
+  }
+
+  substring(beginIndex: any, endIndex = Infinity) {
+    return this.value.substring(beginIndex, endIndex);
+  }
+
+  toJSON() {
+    return this.toString();
+  }
+
+  toLowerCase() {
+    return new JavaString(this.value.toLowerCase());
+  }
+
+  toUpperCase() {
+    return new JavaString(this.value.toUpperCase());
+  }
+
+  toString() {
+    return this.value;
+  }
+
+  toIdString() {
+    return this.value;
+  }
+
+  trim() {
+    return new JavaString(this.value.trim());
+  }
+
+  length() {
+    return this.value && this.value.length;
+  }
+}

--- a/src/value-mapper/tests/array.test.ts
+++ b/src/value-mapper/tests/array.test.ts
@@ -1,0 +1,78 @@
+import { JavaArray } from "../array";
+
+const identityMapper = jest.fn((v) => v);
+
+describe(" Velocity ValueMapper JavaArray", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  it("Should initialize from JS Array", () => {
+    const JS_ARRAY = [1, 2, 3];
+    const arr = new JavaArray(JS_ARRAY, identityMapper);
+    expect(arr.toJSON()).toEqual(JS_ARRAY);
+  });
+
+  it("size", () => {
+    const JS_ARRAY = [1, 2, 3];
+    const arr = new JavaArray(JS_ARRAY, identityMapper);
+    expect(arr.size()).toEqual(JS_ARRAY.length);
+  });
+
+  it("isEmpty", () => {
+    expect(new JavaArray([1, 2, 3], identityMapper).isEmpty()).toBeFalsy();
+    expect(new JavaArray([], identityMapper).isEmpty()).toBeTruthy();
+  });
+
+  it("add", () => {
+    const arr = new JavaArray([], identityMapper);
+    arr.add(1);
+    expect(arr.size()).toEqual(1);
+    expect(arr.toJSON()).toEqual([1]);
+  });
+
+  it("addAll", () => {
+    const NEW_ARR = [1, 2, 3];
+    const arr = new JavaArray([], identityMapper);
+    arr.addAll(NEW_ARR);
+    expect(identityMapper).toBeCalledTimes(NEW_ARR.length);
+    expect(arr.size()).toEqual(NEW_ARR.length);
+    expect(arr.toJSON()).toEqual(NEW_ARR);
+  });
+
+  it("clear", () => {
+    const NEW_ARR = [1, 2, 3];
+    const arr = new JavaArray(NEW_ARR, identityMapper);
+    expect(arr.size()).toEqual(NEW_ARR.length);
+    arr.clear();
+    expect(arr.toJSON()).toEqual([]);
+  });
+
+  it("contains", () => {
+    const NEW_ARR = [1, 2, 3];
+    const arr = new JavaArray(NEW_ARR, identityMapper);
+    expect(arr.contains(1)).toBeTruthy();
+    expect(arr.contains("Z")).toBeFalsy();
+  });
+
+  it("containsAll", () => {
+    const NEW_ARR = [1, 2, 3];
+    const arr = new JavaArray(NEW_ARR, identityMapper);
+    expect(arr.containsAll(NEW_ARR)).toBeTruthy();
+    expect(arr.containsAll([2])).toBeTruthy();
+    expect(arr.containsAll([...NEW_ARR, "Z"])).toBeFalsy();
+  });
+
+  it("remove", () => {
+    const NEW_ARR = [1, 2, 3];
+    const arr = new JavaArray(NEW_ARR, identityMapper);
+    arr.remove(3);
+    expect(arr.toJSON()).toEqual([1, 2]);
+  });
+
+  it("removeAll", () => {
+    const NEW_ARR = [1, 2, 3];
+    const arr = new JavaArray(NEW_ARR, identityMapper);
+    arr.removeAll([3, 2]);
+    expect(arr.toJSON()).toEqual([1]);
+  });
+});

--- a/src/value-mapper/tests/map.test.ts
+++ b/src/value-mapper/tests/map.test.ts
@@ -1,0 +1,94 @@
+import { JavaArray } from "../array";
+import { JavaMap } from "../map";
+import { JavaString } from "../string";
+import { valueMapper as mapper } from "../mapper";
+
+describe("JavaMap", () => {
+  let identityMapper = jest.fn().mockImplementation((val) => val);
+
+  beforeEach(() => {
+    identityMapper = jest.fn().mockImplementation((val) => val);
+  });
+  it("New Map", () => {
+    const obj = { foo: 1, bar: 2 };
+    const map = new JavaMap(obj, identityMapper);
+    expect(map.toJSON()).toEqual(obj);
+  });
+
+  it("clear", () => {
+    const obj = { foo: 1, bar: 2 };
+    const map = new JavaMap(obj, identityMapper);
+    map.clear();
+    expect(map.toJSON()).toEqual({});
+  });
+
+  it("containsKey", () => {
+    const obj = { foo: 1, bar: 2 };
+    const map = new JavaMap(obj, identityMapper);
+    expect(map.containsKey("foo")).toBeTruthy();
+    expect(map.containsKey("bax")).toBeFalsy();
+  });
+
+  it("containsValue", () => {
+    const obj = { foo: "Foo Value", bar: "Bar Value" };
+    const map = new JavaMap(obj, identityMapper);
+    expect(map.containsValue("Foo Value")).toBeTruthy();
+    expect(map.containsKey("bax value")).toBeFalsy();
+  });
+
+  it("entrySet", () => {
+    const obj = { foo: "Foo Value", bar: "Bar Value" };
+    const map = new JavaMap(obj, identityMapper);
+    expect(map.entrySet().toJSON()).toEqual([
+      { key: "foo", value: "Foo Value" },
+      { key: "bar", value: "Bar Value" },
+    ]);
+  });
+
+  it("equal", () => {
+    const obj = { foo: "Foo Value", bar: "Bar Value" };
+    const map = new JavaMap(obj, identityMapper);
+    const map2 = new JavaMap(obj, identityMapper);
+    expect(map.equals(map2)).toBeTruthy();
+  });
+
+  it("get", () => {
+    const obj = { foo: "Foo Value", bar: "Bar Value" };
+    const map = new JavaMap(obj, identityMapper);
+    expect(map.get("foo")).toEqual("Foo Value");
+    expect(map.get("foo1")).toBeNull();
+  });
+
+  it("isEmpty", () => {
+    const obj = { foo: "Foo Value", bar: "Bar Value" };
+    const map = new JavaMap(obj, identityMapper);
+    expect(map.isEmpty()).toBeFalsy();
+    expect(new JavaMap({}, identityMapper).isEmpty()).toBeTruthy();
+  });
+
+  it("keySet", () => {
+    const obj = { foo: "Foo Value", bar: "Bar Value" };
+    const map = new JavaMap(obj, identityMapper);
+    expect(map.keySet().toJSON()).toEqual(["foo", "bar"]);
+  });
+
+  it("keySet returns a JavaArray with each element of type JavaString", () => {
+    const obj = { foo: "Foo Value", bar: "Bar Value" };
+    const map = new JavaMap(obj, mapper);
+    expect(map.keySet()).toEqual(
+      new JavaArray([new JavaString("foo"), new JavaString("bar")], mapper)
+    );
+  });
+
+  it("put", () => {
+    const map = new JavaMap({}, identityMapper);
+    map.put("foo", "Foo Value");
+    expect(map.toJSON()).toEqual({ foo: "Foo Value" });
+  });
+
+  it("putAll", () => {
+    const map = new JavaMap({}, identityMapper);
+    map.putAll({ foo: "Foo Value", bar: "Bar Value" });
+    expect(map.toJSON()).toEqual({ foo: "Foo Value", bar: "Bar Value" });
+  });
+});

--- a/src/value-mapper/tests/string.test.ts
+++ b/src/value-mapper/tests/string.test.ts
@@ -1,0 +1,164 @@
+import { JavaString } from "../string";
+
+describe("JavaString", () => {
+  it("replaceAll", () => {
+    const str = new JavaString("foo bar foo bar foo bar Foo");
+    const replacedStr = str.replaceAll("foo", "baz");
+    expect(replacedStr.toString()).toEqual("baz bar baz bar baz bar Foo");
+    expect(replacedStr.toIdString()).toEqual("baz bar baz bar baz bar Foo");
+    expect(replacedStr.toJSON()).toEqual("baz bar baz bar baz bar Foo");
+  });
+
+  it("length", () => {
+    const str1 = new JavaString("foo");
+    expect(str1.length()).toEqual(3);
+  });
+
+  it("concat", () => {
+    const str1 = new JavaString("foo");
+    expect(str1.concat(new JavaString("bar")).toString()).toEqual("foobar");
+  });
+
+  it("contains", () => {
+    const str = new JavaString(
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
+    );
+    expect(str.contains(new JavaString("ipsum"))).toEqual(true);
+    expect(str.contains(new JavaString("DOLOR"))).toEqual(false);
+  });
+
+  it("endsWith", () => {
+    const str = new JavaString(
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
+    );
+    expect(str.endsWith(new JavaString("ipsum"))).toEqual(false);
+    expect(str.endsWith(new JavaString("elit"))).toEqual(true);
+  });
+
+  it("equals", () => {
+    const str = new JavaString(
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
+    );
+    expect(
+      str.equals(
+        new JavaString(
+          "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
+        )
+      )
+    ).toEqual(true);
+    expect(str.equals(new JavaString("ipsum"))).toEqual(false);
+  });
+
+  it("indexOf", () => {
+    const str = new JavaString(
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
+    );
+    expect(str.indexOf(new JavaString("ipsum"))).toEqual(6);
+    expect(str.indexOf(new JavaString("ipsum"), 10)).toEqual(-1);
+  });
+
+  it("isEmpty", () => {
+    const emptyStr = new JavaString("");
+    expect(emptyStr.isEmpty()).toEqual(true);
+
+    const str = new JavaString("foo bar");
+    expect(str.isEmpty()).toEqual(false);
+  });
+
+  it("lastIndexOf", () => {
+    const str = new JavaString(
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem"
+    );
+    expect(str.lastIndexOf(new JavaString("Lorem"))).toEqual(57);
+    expect(str.lastIndexOf(new JavaString("Lorem"), 10)).toEqual(0);
+
+    expect(str.lastIndexOf(new JavaString("foo"))).toEqual(-1);
+  });
+
+  it("matches", () => {
+    const str = new JavaString("foo bar");
+
+    expect(str.matches("foo")).toEqual(true);
+    expect(str.matches("lorem")).toEqual(false);
+    expect(str.matches("(foo|test)")).toEqual(true);
+  });
+
+  it("replace", () => {
+    const str = new JavaString("foo foo bar");
+
+    expect(str.replace("foo", "bar").toString()).toEqual("bar bar bar");
+    expect(str.replace("test", "bar").toString()).toEqual("foo foo bar");
+  });
+
+  it("replaceFirst", () => {
+    const str = new JavaString("foo foo bar");
+
+    expect(str.replaceFirst("foo", "bar").toString()).toEqual("bar foo bar");
+    expect(str.replaceFirst("test", "bar").toString()).toEqual("foo foo bar");
+  });
+
+  it("split", () => {
+    const str = new JavaString("foo bar foo bar foo bar Foo");
+
+    const splitStr = str.split(new JavaString(" "));
+    expect(splitStr.length).toEqual(7);
+    expect(splitStr.toJSON()).toEqual([
+      "foo",
+      "bar",
+      "foo",
+      "bar",
+      "foo",
+      "bar",
+      "Foo",
+    ]);
+
+    const splitStr2 = str.split(new JavaString("(foo)"));
+    expect(splitStr2.length).toEqual(4);
+    expect(splitStr2.toJSON()).toEqual(["", " bar ", " bar ", " bar Foo"]);
+  });
+
+  it("startsWith", () => {
+    const str = new JavaString(
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
+    );
+    expect(str.startsWith(new JavaString("ipsum"))).toEqual(false);
+    expect(str.startsWith(new JavaString("Lorem"))).toEqual(true);
+
+    expect(str.startsWith(new JavaString("Lorem"), 10)).toEqual(false);
+  });
+
+  it("substring", () => {
+    const str = new JavaString(
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
+    );
+    expect(str.substring(0).toString()).toEqual(
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
+    );
+    expect(str.substring(0, 1).toString()).toEqual("L");
+    expect(str.substring(6, 11).toString()).toEqual("ipsum");
+  });
+
+  it("toLowerCase", () => {
+    const str = new JavaString("Foo BaR");
+    expect(str.toLowerCase().toString()).toEqual("foo bar");
+  });
+
+  it("toUpperCase", () => {
+    const str = new JavaString("Foo BaR");
+    expect(str.toUpperCase().toString()).toEqual("FOO BAR");
+  });
+
+  it("trim", () => {
+    const str = new JavaString("foo bar");
+    expect(str.trim().toString()).toEqual("foo bar");
+
+    const str2 = new JavaString("   foo bar");
+    expect(str2.trim().toString()).toEqual("foo bar");
+
+    const str3 = new JavaString("   foo bar      ");
+    expect(str3.trim().toString()).toEqual("foo bar");
+
+    const str4 = new JavaString("foo bar      ");
+    expect(str4.trim().toString()).toEqual("foo bar");
+  });
+});

--- a/src/value-mapper/tests/to-json.test.ts
+++ b/src/value-mapper/tests/to-json.test.ts
@@ -1,0 +1,23 @@
+import { toJSON } from "../to-json";
+
+describe("Velocity - ValueMapper toJSON", () => {
+  it("should call toJSON if the value object has method toJSON", () => {
+    const JSON_VALUE = "MOCK_JSON_VALUE";
+    const testObj = {
+      toJSON: jest.fn().mockReturnValue(JSON_VALUE),
+    };
+    expect(toJSON(testObj)).toEqual(JSON_VALUE);
+    expect(testObj.toJSON).toHaveBeenCalled();
+  });
+
+  it("should not call toJSON if the object is null", () => {
+    expect(toJSON(null)).toEqual(null);
+  });
+
+  it("should return the source object if it doesnot implement toJSON", () => {
+    const testObj = {
+      foo: "Foo",
+    };
+    expect(toJSON(testObj)).toEqual(testObj);
+  });
+});

--- a/src/value-mapper/to-json.ts
+++ b/src/value-mapper/to-json.ts
@@ -1,0 +1,6 @@
+export function toJSON(value: any) {
+  if (typeof value === "object" && value != null && "toJSON" in value) {
+    return value.toJSON();
+  }
+  return value;
+}


### PR DESCRIPTION
This pull request is highly inspired by the code available in amplify-appsync-simulator (see https://github.com/aws-amplify/amplify-cli/tree/master/packages/amplify-appsync-simulator/src/velocity)

Reason why I created this pull request is that the amplify-appsync-simulator does way more than I need. I only want to create unittests on VTL templates, so we can check if our templates are correct.

Than I found this great library and it worked for a lot of our templates, but a couple where failing. For one issue I created https://github.com/skyhookadventure/appsync-template-tester/issues/17, but it seems more functions are not supported.

This PR adds this functionality, so you can use [1,2,3].contains(1) and the VTL parser will return true instead of a string like '[1,2,3].contains(1)'

Let me know if this is something that can be merged, so I can keep on using this library and otherwise I will continue on our fork.